### PR TITLE
feat: add Transcribed status badge

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -116,6 +116,7 @@ function EpisodeCard({
         <SignalBadge
           status={episode.status}
           hasSummary={!!episode.summary?.markdownContent}
+          hasTranscript={!!episode.transcriptUrl}
         />
         {isUnprocessed && (
           <Button

--- a/src/components/signal-badge.tsx
+++ b/src/components/signal-badge.tsx
@@ -1,5 +1,6 @@
 import {
   AlertCircleIcon,
+  File01Icon,
   Loading03Icon,
   TickDouble02Icon,
   TimeQuarterPassIcon,
@@ -16,9 +17,27 @@ export type SignalBadgeStatus =
 export interface SignalBadgeProps {
   status: SignalBadgeStatus;
   hasSummary: boolean;
+  hasTranscript?: boolean;
 }
 
-export function SignalBadge({ status, hasSummary }: SignalBadgeProps) {
+export function SignalBadge({
+  status,
+  hasSummary,
+  hasTranscript,
+}: SignalBadgeProps) {
+  // Transcribed but not summarized
+  if (hasTranscript && !hasSummary && status === "pending") {
+    return (
+      <div
+        className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-purple-50 dark:bg-purple-950/30 text-purple-700 dark:text-purple-400"
+        title="Transcript available, ready for summary"
+      >
+        <HugeiconsIcon icon={File01Icon} size={16} />
+        <span className="text-xs font-medium">Transcribed</span>
+      </div>
+    );
+  }
+
   if (status === "pending" && !hasSummary) {
     return (
       <div


### PR DESCRIPTION
## Summary
- Add new "Transcribed" status badge (purple) for episodes that have transcript but no summary
- Helps distinguish between:
  - **Unprocessed** (gray) - no transcript, no summary
  - **Transcribed** (purple) - has transcript, no summary yet
  - **Summarized** (green) - has both transcript and summary

## Test plan
- [ ] View dashboard with mix of episodes
- [ ] Verify episodes with `transcriptUrl` but no summary show purple "Transcribed" badge
- [ ] Verify episodes without transcript show gray "Unprocessed" badge
- [ ] Verify episodes with summary show green "Summarized" badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)